### PR TITLE
implement window pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Hotkeys:
         CTRL + 1..4            -> moves active window to desktop 1..4
         ALT + CTRL + SHIFT + Q -> exits the program
         ALT + CTRL + SHIFT + S -> starts/stops handling of other hotkeys
+        ALT + CTRL + SHIFT + P -> pin active window (makes it always visible)
 
 the nerds can build it with
 

--- a/virgo.c
+++ b/virgo.c
@@ -322,6 +322,9 @@ static void virgo_move_to_desk(Virgo *v, unsigned desk)
 	}
 	virgo_update(v);
 	hwnd = GetForegroundWindow();
+	if (virgo_is_pinned(v, hwnd)) {
+		return;
+	}
 	if (!hwnd || !is_valid_window(hwnd)) {
 		return;
 	}


### PR DESCRIPTION
this is useful when you're running a multi-monitor setup and want some windows to persist on all desktops (such as having a performance monitor on your 2nd monitor)

the hotkey for pinning is CTRL + SHIFT + ALT + P

I opted for a small fixed size array to save memory since you're not gonna pin many windows anyway

it's kind of a big patch (40+ lines) so I understand if you don't want to merge it to keep the lines of code count low

tecnically using 0 as the empty hwnd value is wrong, but it's highly unlikely that a window that isn't a system window is gonna have HWND = 0, so it should be fine and it saves having to initialize the array to INVALID_WINDOW_HANDLE in virgo_init